### PR TITLE
reload() was moved into importlib in Python 3

### DIFF
--- a/ci/main.py
+++ b/ci/main.py
@@ -4,10 +4,11 @@ import json, sys
 import sqlite3
 from collections import OrderedDict
 
-
-reload(sys)
-sys.setdefaultencoding('utf-8')
-
+try:               # Python 2
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
+except NameError:  # Python 3
+    pass
 
 c = sqlite3.connect('ci.db')
 


### PR DESCRIPTION
The builtin __reload()__ was moved into [importlib](https://docs.python.org/3/library/importlib.html#importlib.reload) in Python 3 because it was being overused and led to odd behavior that was often difficult to diagnose.  Here we are trying to __reload(sys)__ probably because 'utf-8' encoding and Unicode strs are not the default in Python 2.  They are however the default in Python 3 so this PR therefor suggests that a __pass__ would be satisfactory in Python 3.